### PR TITLE
[cloudprotocol] Fix desired status format version type

### DIFF
--- a/api/cloudprotocol/desiredstatus.go
+++ b/api/cloudprotocol/desiredstatus.go
@@ -87,7 +87,7 @@ type NodeConfig struct {
 
 // UnitConfig unit configuration.
 type UnitConfig struct {
-	FormatVersion string       `json:"formatVersion"`
+	FormatVersion interface{}  `json:"formatVersion"`
 	Version       string       `json:"version"`
 	Nodes         []NodeConfig `json:"nodes"`
 }


### PR DESCRIPTION
As per latest cloud protocol format version might be int or string
https://github.com/aosedge/aos_protocols/blob/main/src/cloud_common/protocols/unit/unit_config.py#L243