### PR TITLE
[utils,grpchelpers] Remove GracefulStop call on close grpc server

### DIFF
--- a/utils/grpchelpers/grpcserver.go
+++ b/utils/grpchelpers/grpcserver.go
@@ -120,7 +120,6 @@ func (server *GRPCServer) StopServer() {
 
 func (server *GRPCServer) stopGRPCServer() {
 	if server.grpcServer != nil {
-		server.grpcServer.Stop()
 		server.grpcServer.GracefulStop()
 	}
 


### PR DESCRIPTION
Calling GracefulStop after Stop doesn't make sens as Stop already released all resources. Also, with current grpc version GracefulStop freezes even all clients streams are closed.