### PR TITLE
[utils,grpchelpers] Replace grpc server GracefulStop with Stop

### DIFF
--- a/utils/grpchelpers/grpcserver.go
+++ b/utils/grpchelpers/grpcserver.go
@@ -120,7 +120,7 @@ func (server *GRPCServer) StopServer() {
 
 func (server *GRPCServer) stopGRPCServer() {
 	if server.grpcServer != nil {
-		server.grpcServer.GracefulStop()
+		server.grpcServer.Stop()
 	}
 
 	server.stopWG.Wait()


### PR DESCRIPTION
We don't properly handle graceful stop on all out servers. So, remove it and use force stop instead.